### PR TITLE
fixed borrowed,receiving, and requested files to link to search for libraries

### DIFF
--- a/src/components/Shelf/Borrowed.js
+++ b/src/components/Shelf/Borrowed.js
@@ -78,7 +78,7 @@ const Borrowed = () => {
             <div>
               <h6>You have no books that you are currently borrowing</h6>
               <p>Search for books to borrow?</p>
-              <NavLink to="/shelf/search">
+              <NavLink to="/lookup/search">
                 <Button>Search for books</Button>
               </NavLink>
             </div>

--- a/src/components/Tranactions/Receiving.js
+++ b/src/components/Tranactions/Receiving.js
@@ -87,7 +87,7 @@ const Receiving = () => {
             <h6>Then the other user can set a book to be loaned to you</h6>
             <h6>What are you waiting for?</h6>
             <h6>Start searching libraries in your area</h6>
-            <NavLink to="/shelf/search">
+            <NavLink to="/lookup/search">
               <Button>Search libraries</Button>
             </NavLink>
           </EmptyBooksContainer>

--- a/src/components/Tranactions/Requested.js
+++ b/src/components/Tranactions/Requested.js
@@ -94,7 +94,7 @@ const Requested = () => {
               <h6>When a user wants to read a book from your library</h6>
               <h6>It'll show up here</h6>
               <h6>Did you mean to borrow a book?</h6>
-              <NavLink to="/shelf/search">
+              <NavLink to="/lookup/search">
                 <Button>Search your area</Button>
               </NavLink>
             </div>


### PR DESCRIPTION
When users would go to transactions -> requested -> and click on search your area button it wasn't taking them to the search libraries page (it would be a blank page). Same for receiving and requested.